### PR TITLE
fix: internals leaking when using Object's props to look up the schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function plugin (fastify, opts, next) {
 }
 
 function createStore (schemas) {
-  const store = {}
+  const store = Object.create(null)
   for (var i = 0; i < schemas.length; i++) {
     var id = schemas[i].id
     if (store[id] !== undefined) {

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function plugin (fastify, opts, next) {
   next()
 
   function schema (id) {
-    var stringify = store[id]
+    const stringify = store[id]
     if (stringify === undefined) {
       return this
     }
@@ -20,8 +20,8 @@ function plugin (fastify, opts, next) {
 
 function createStore (schemas) {
   const store = Object.create(null)
-  for (var i = 0; i < schemas.length; i++) {
-    var id = schemas[i].id
+  for (let i = 0; i < schemas.length; i++) {
+    const id = schemas[i].id
     if (store[id] !== undefined) {
       return new Error(`Schema with id '${id}' is already defined`)
     }

--- a/test.js
+++ b/test.js
@@ -75,3 +75,46 @@ test('Schema with same id', t => {
 
   fastify.close()
 })
+
+test('Client supplies `toString`, `__proto__` and `constructor` when no there is no schema with these ids', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+  fastify.register(anySchema, {
+    schemas: []
+  })
+
+  const expectedPayload = { hello: 'world' }
+
+  fastify.get('/:schema', (req, reply) => {
+    reply
+      .schema(req.params.schema)
+      .send(expectedPayload)
+  })
+
+  fastify.inject({
+    url: '/toString',
+    method: 'GET'
+  }, res => {
+    const payload = JSON.parse(res.payload)
+    t.deepEqual(payload, expectedPayload)
+
+    fastify.inject({
+      url: '/__proto__',
+      method: 'GET'
+    }, res => {
+      const payload = JSON.parse(res.payload)
+      t.deepEqual(payload, expectedPayload)
+
+      fastify.inject({
+        url: '/constructor',
+        method: 'GET'
+      }, res => {
+        const payload = JSON.parse(res.payload)
+        t.deepEqual(payload, expectedPayload)
+
+        fastify.close()
+      })
+    })
+  })
+})


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

---

This is intended to be a fix for an undesired behavior. Let me know if I'm wrong.  
Also, I've removed occurrences of `var` keyword as the code is using `const` already. 

Basically, `any-schema-you-like` is using the object literal `{}` as a store, then we'll get odd responses when we have the following lines evaluated and `id` is some `Object.prototype` property:

https://github.com/fastify/any-schema-you-like/blob/b772b5a6d3c962aad59f5d36fd4d46f65f0a29f3/index.js#L13-L17

### before this PR

Given this app as an example:

```js
const fastify = require('fastify')()

fastify.register(require('any-schema-you-like'), {
  schemas: [] // no schema
})

fastify.get('/:schema', (req, reply) => {
  reply
    .schema(req.params.schema)
    .send({ hello: 'world' }) // then this should be the response
})

fastify.listen(3000, err => {
  if (err) throw err
  console.log(`server listening on ${fastify.server.address().port}`)
})
```

Tests:

```bash
$ curl "localhost:3000/toString"
[object Object]

$ curl "localhost:3000/__proto__" | jq
{
  "statusCode": 500,
  "error": "Internal Server Error",
  "message": "reply[kReplySerializer] is not a function"
}

$ curl "localhost:3000/constructor" | jq
{
  "statusCode": 500,
  "code": "FST_ERR_REP_INVALID_PAYLOAD_TYPE",
  "error": "Internal Server Error",
  "message": "Attempted to send payload of invalid type 'object'. Expected a string or Buffer."
}
```

### after

```bash
$ curl "localhost:3000/toString"
{"hello":"world"}

$ curl "localhost:3000/__proto__" | jq
{
  "hello": "world"
}


$ curl "localhost:3000/constructor" | jq
{
  "hello": "world"
}
```
